### PR TITLE
docs: make correction to device argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import Index from "insynctive";
 
 const insynctive = new Index("192.168.1.15");
 
-insynctive.on("onDeviceStatusChange", async (device) => {
+insynctive.on("onDeviceStatusChange", async ({ device }) => {
     const deviceData = await device.toJSON();
 
     console.log(deviceData);


### PR DESCRIPTION
I came across this error when following the example in your docs:
`TypeError: device.toJSON is not a function`

I see device is now an object property. I've updated the docs accordingly.